### PR TITLE
Increase precision of values printed in main window

### DIFF
--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -418,7 +418,7 @@ void MainWindow::update_status_bar()
 
         vec4 mouse_pos = get_stage_coordinates(mouse_x, mouse_y);
 
-        message << std::fixed << std::setprecision(1) << "("
+        message << std::fixed << std::setprecision(3) << "("
                 << static_cast<int>(floor(mouse_pos.x())) << ", "
                 << static_cast<int>(floor(mouse_pos.y())) << ")\t"
                 << cam->compute_zoom() * 100.0 << "%";


### PR DESCRIPTION
For float images it isn't sufficient to have every value rounded up to one number after comma, so I propose to have this limit increased to 3. For integer images this doesn't change anything